### PR TITLE
Fixes for Linux Install

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -8,7 +8,7 @@ _skip_if_exists:
 _tasks:
   - uv sync --all-extras
   - uv venv
-  - source .venv/bin/activate
+  - . .venv/bin/activate
   - uv run nox -s setup
 
 project_icon:

--- a/install.sh
+++ b/install.sh
@@ -3,36 +3,27 @@
 
 echo "Installing dev tools to enable project management with oe-python-template and derivatives ..."
 
-LINUX_APT_TOOLS=(
-    "curl;curl;https://curl.se/"
-)
+# Define tool lists as strings with delimiters for cross-platform compatibility
+LINUX_APT_TOOLS="curl;curl;https://curl.se/"
 
-BREW_TOOLS=(
-    "uv;uv;https://docs.astral.sh/uv/"
-    "git;git;https://git-scm.com/"
-    "gpg;gnupg;https://gnupg.org/"
-    "gmake;make;https://www.gnu.org/software/make/"
-    "jq;jq;https://jqlang.org/"
-    "xmllint;libxml2;https://en.wikipedia.org/wiki/Libxml2"
-    "act;act;https://nektosact.com/"
-    "pinact;pinact;https://github.com/suzuki-shunsuke/pinact"
-    "trivy;trivy;https://trivy.dev/latest/"
-    "pnpm;pnpm;https://pnpm.io/"
-    "magick;imagemagick;https://imagemagick.org/"
-    "nixpacks;nixpacks;https://nixpacks.com/"
-)
+BREW_TOOLS="uv;uv;https://docs.astral.sh/uv/
+git;git;https://git-scm.com/
+gpg;gnupg;https://gnupg.org/
+gmake;make;https://www.gnu.org/software/make/
+jq;jq;https://jqlang.org/
+xmllint;libxml2;https://en.wikipedia.org/wiki/Libxml2
+act;act;https://nektosact.com/
+pinact;pinact;https://github.com/suzuki-shunsuke/pinact
+trivy;trivy;https://trivy.dev/latest/
+pnpm;pnpm;https://pnpm.io/
+magick;imagemagick;https://imagemagick.org/
+nixpacks;nixpacks;https://nixpacks.com/"
 
-MAC_BREW_TOOLS=(
-    "pinentry-mac;pinentry-mac;https://github.com/GPGTools/pinentry"
-)
+MAC_BREW_TOOLS="pinentry-mac;pinentry-mac;https://github.com/GPGTools/pinentry"
 
-LINUX_BREW_TOOLS=(
-    # Linux-specific Homebrew tools will be added here
-)
+LINUX_BREW_TOOLS=""
 
-UV_TOOLS=(
-    "copier;copier;https://copier.readthedocs.io/"
-)
+UV_TOOLS="copier;copier;https://copier.readthedocs.io/"
 
 # Function to install/update brew tools
 install_or_upgrade_brew_tool() {
@@ -40,14 +31,17 @@ install_or_upgrade_brew_tool() {
     local package=$2
     local url=$3
 
-    if command -v "$tool" &> /dev/null; then
+    if command -v "$tool" > /dev/null 2>&1; then
         tool_path=$(command -v "$tool")
-        if [[ "$tool_path" == *"brew/"* ]]; then
-            echo "$tool already installed via Homebrew at $tool_path, upgrading..."
-            brew upgrade "$package" || true
-        else
-            echo "$tool already installed at $tool_path, skipping..."
-        fi
+        case "$tool_path" in
+            *brew/*)
+                echo "$tool already installed via Homebrew at $tool_path, upgrading..."
+                brew upgrade "$package" || true
+                ;;
+            *)
+                echo "$tool already installed at $tool_path, skipping..."
+                ;;
+        esac
     else
         echo "Installing $tool from $package... # $url"
         brew install "$package"
@@ -60,7 +54,7 @@ install_or_update_linux_apt_tool() {
     local package=$2
     local url=$3
 
-    if command -v "$tool" &> /dev/null; then
+    if command -v "$tool" > /dev/null 2>&1; then
         echo "$tool already installed at $(command -v "$tool"), skipping..."
     else
         echo "Installing $tool... # $url"
@@ -73,7 +67,7 @@ install_or_update_uv_tool() {
     local tool=$1
     local url=$3
 
-    if command -v "$tool" &> /dev/null; then
+    if command -v "$tool" > /dev/null 2>&1; then
         echo "$tool already installed at $(command -v "$tool"), updating..."
         uv tool update "$tool"
     else
@@ -83,46 +77,65 @@ install_or_update_uv_tool() {
 }
 
 # Install/update Linux packages
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    for tool_entry in "${LINUX_APT_TOOLS[@]}"; do
-        IFS=";" read -r tool package url <<< "$tool_entry"
-        install_or_update_linux_apt_tool "$tool" "$package" "$url"
+if [ "$(uname -s | cut -c1-5)" = "Linux" ]; then
+    echo "$LINUX_APT_TOOLS" | while IFS=';' read -r tool package url; do
+        [ -n "$tool" ] && install_or_update_linux_apt_tool "$tool" "$package" "$url"
     done
 fi
 
 # Install/update Homebrew itself
-if ! command -v brew &> /dev/null; then
+if ! command -v brew > /dev/null 2>&1; then
     echo "Installing Homebrew... # https://brew.sh/"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    
+    # Add Homebrew to PATH based on platform
+    if [ "$(uname -s)" = "Darwin" ]; then
+        # macOS - Homebrew path setup
+        if [ "$(uname -m)" = "arm64" ]; then
+            # M1/M2 Mac
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+            echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME/.zprofile"
+        else
+            # Intel Mac
+            eval "$(/usr/local/bin/brew shellenv)"
+            echo 'eval "$(/usr/local/bin/brew shellenv)"' >> "$HOME/.zprofile"
+        fi
+    elif [ "$(uname -s | cut -c1-5)" = "Linux" ]; then
+        # Linux - Homebrew path setup
+        if [ -d "$HOME/.linuxbrew" ]; then
+            eval "$($HOME/.linuxbrew/bin/brew shellenv)"
+        fi
+        if [ -d "/home/linuxbrew/.linuxbrew" ]; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        fi
+        brew_prefix=$(brew --prefix 2>/dev/null || echo "/home/linuxbrew/.linuxbrew")
+        echo "eval \$(${brew_prefix}/bin/brew shellenv)" >> "$HOME/.bashrc"
+    fi
 else
     echo "Homebrew already installed at $(command -v brew), updating..."
     brew update
 fi
 
 # Install/update Homebrew tools
-for tool_entry in "${BREW_TOOLS[@]}"; do
-    IFS=";" read -r tool package url <<< "$tool_entry"
-    install_or_upgrade_brew_tool "$tool" "$package" "$url"
+echo "$BREW_TOOLS" | while IFS=';' read -r tool package url; do
+    [ -n "$tool" ] && install_or_upgrade_brew_tool "$tool" "$package" "$url"
 done
 
 # Install/update Homebrew tools for macOS
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    for tool_entry in "${MAC_BREW_TOOLS[@]}"; do
-        IFS=";" read -r tool package url <<< "$tool_entry"
-        install_or_upgrade_brew_tool "$tool" "$package" "$url"
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "$MAC_BREW_TOOLS" | while IFS=';' read -r tool package url; do
+        [ -n "$tool" ] && install_or_upgrade_brew_tool "$tool" "$package" "$url"
     done
 fi
 
 # Install/update Homebrew tools for Linux
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    for tool_entry in "${LINUX_BREW_TOOLS[@]}"; do
-        IFS=";" read -r tool package url <<< "$tool_entry"
-        install_or_upgrade_brew_tool "$tool" "$package" "$url"
+if [ "$(uname -s | cut -c1-5)" = "Linux" ]; then
+    echo "$LINUX_BREW_TOOLS" | while IFS=';' read -r tool package url; do
+        [ -n "$tool" ] && install_or_upgrade_brew_tool "$tool" "$package" "$url"
     done
 fi
 
 # Install/update UV tools
-for tool_entry in "${UV_TOOLS[@]}"; do
-    IFS=";" read -r tool package url <<< "$tool_entry"
-    install_or_update_uv_tool "$tool" "$url"
+echo "$UV_TOOLS" | while IFS=';' read -r tool package url; do
+    [ -n "$tool" ] && install_or_update_uv_tool "$tool" "$url"
 done


### PR DESCRIPTION
This PR fixes the `install.sh` and `copier.yml` for linux. Specifically, `sh` in linux cannot process some of the syntactic sugars that `bash/zsh` offer, so they need to be rewritten to work properly. The modified scripts should also work under ios.